### PR TITLE
Remove inline comments from JavaScript functions

### DIFF
--- a/view/frontend/templates/hyva/script-pusher.phtml
+++ b/view/frontend/templates/hyva/script-pusher.phtml
@@ -57,7 +57,6 @@ declare(strict_types=1);
         }
 
         try {
-            // Add logic to store event
             if ((eventData.event === 'trytagging_begin_checkout' || eventData.event === 'trytagging_view_cart') && eventData.marketing) {
                 const simpleHash = window.tagging_gtm_simple_hash(eventData);
                 const advancedHash = window.tagging_gtm_advanced_hash(eventData);
@@ -66,7 +65,6 @@ declare(strict_types=1);
                 window.tagging_gtm_save_hash(advancedHash, eventData.marketing);
             }
         } catch (error) {
-            // Ensure we don't break the event
             console.error('Error generating hashes:', error);
         }
 

--- a/view/frontend/templates/iframe.phtml
+++ b/view/frontend/templates/iframe.phtml
@@ -42,14 +42,12 @@ window.tagging_gtm_simple_hash = function(eventData) {
 
     const parts = [];
 
-    // Add items and quantities
     eventData.ecommerce.items.forEach(item => {
         const itemId = item.item_id || "";
         const quantity = item.quantity || 0;
         parts.push(`i_id=${itemId}&qt=${quantity}`);
     });
 
-    // Join all parts and encode to base64
     const value = parts.join("&");
     return btoa(value);
 }
@@ -66,19 +64,16 @@ window.tagging_gtm_advanced_hash = function(eventData) {
 
     const parts = [];
 
-    // Add items and quantities
     eventData.ecommerce.items.forEach(item => {
         const itemId = item.item_id || "";
         const quantity = item.quantity || 0;
         parts.push(`i_id=${itemId}&qt=${quantity}`);
     });
 
-    // Add user agent (normalized: lowercase, spaces removed)
     const userAgent = navigator.userAgent || "";
     const normalizedUserAgent = userAgent.toLowerCase().replace(/\s+/g, "");
     parts.push(`--ua=${normalizedUserAgent}`);
 
-    // Join all parts and encode to base64
     const value = parts.join("&");
     return btoa(value);
 }


### PR DESCRIPTION
## Summary
This pull request removes inline comments from JavaScript functions in the GTM tagging implementation. The code functionality remains unchanged; only non-essential comments have been removed to reduce code verbosity.

## Key Changes
- Removed inline comments from `tagging_gtm_simple_hash()` function in iframe.phtml
- Removed inline comments from `tagging_gtm_advanced_hash()` function in iframe.phtml
- Removed inline comments from event handling logic in script-pusher.phtml

## Details
The following comments were removed as they were self-explanatory given the surrounding code:
- "Add items and quantities" - the forEach loop clearly iterates over items
- "Join all parts and encode to base64" - the variable names and btoa() call are self-documenting
- "Add user agent (normalized: lowercase, spaces removed)" - the code clearly shows normalization
- "Add logic to store event" - the conditional and function calls are explicit
- "Ensure we don't break the event" - the error handling intent is clear from context

No functional changes were made to the code logic or behavior.

https://claude.ai/code/session_01JhJgj1WnVFrireJtTLxTCb