### PR TITLE
Fix JavaScript function declaration syntax in iframe template

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "tagginggroup/gtm",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "license": "OSL-3.0",
   "type": "magento2-module",
   "description": "AdPage tagging integration for Magento 2",

--- a/view/frontend/templates/iframe.phtml
+++ b/view/frontend/templates/iframe.phtml
@@ -50,7 +50,7 @@ window.tagging_gtm_simple_hash = function(eventData) {
 
     const value = parts.join("&");
     return btoa(value);
-}
+};
 
 /**
  * Generate advanced hash based on items, quantities, and user agent
@@ -76,7 +76,7 @@ window.tagging_gtm_advanced_hash = function(eventData) {
 
     const value = parts.join("&");
     return btoa(value);
-}
+};
 
 window.tagging_gtm_save_hash = function(hash, marketingObject) {
     if (!hash || !marketingObject) {
@@ -99,7 +99,7 @@ window.tagging_gtm_save_hash = function(hash, marketingObject) {
     .catch((err) => {
         console.error(`Error sending data to API`, err);
     });
-}';
+};';
     
     if ($isHyva): ?>
         <script><?= $mainScript ?></script><?php $hyvaCsp->registerInlineScript() ?>


### PR DESCRIPTION
## Summary
This PR corrects JavaScript syntax errors in the iframe template by converting function declarations to proper function expressions with semicolons.

## Key Changes
- Changed `window.tagging_gtm_simple_hash = function(eventData) { ... }` to end with `};` instead of `}`
- Changed `window.tagging_gtm_advanced_hash = function(eventData) { ... }` to end with `};` instead of `}`
- Changed `window.tagging_gtm_save_hash = function(hash, marketingObject) { ... }` to end with `};` instead of `}`

## Implementation Details
These changes ensure proper JavaScript syntax for function expressions assigned to window objects. Function expressions should be terminated with a semicolon, following JavaScript best practices and linting standards. This prevents potential syntax errors and improves code consistency across the codebase.

https://claude.ai/code/session_01UA52TPmLooaznkU249WJze