### PR TITLE
Add NewCustomerResolverInterface extension point for new_customer field

### DIFF
--- a/Api/NewCustomerResolverInterface.php
+++ b/Api/NewCustomerResolverInterface.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Tagging\GTM\Api;
+
+use Magento\Sales\Api\Data\OrderInterface;
+
+interface NewCustomerResolverInterface
+{
+    /**
+     * Determine whether the given order belongs to a new customer for the
+     * purpose of the `new_customer` field in the GTM data layer and webhook.
+     *
+     * Merchants can override this via a DI preference to replace the default
+     * (guest = new customer) heuristic with e.g. a prior-order-count check.
+     *
+     * @param OrderInterface $order
+     * @return bool
+     */
+    public function isNewCustomer(OrderInterface $order): bool;
+}

--- a/DataLayer/Event/Purchase.php
+++ b/DataLayer/Event/Purchase.php
@@ -6,6 +6,7 @@ namespace Tagging\GTM\DataLayer\Event;
 
 use Magento\Sales\Api\Data\OrderInterface;
 use Tagging\GTM\Api\Data\EventInterface;
+use Tagging\GTM\Api\NewCustomerResolverInterface;
 use Tagging\GTM\Config\Config;
 use Tagging\GTM\DataLayer\Tag\Order\OrderItems;
 use Tagging\GTM\Util\PriceFormatter;
@@ -16,15 +17,18 @@ class Purchase implements EventInterface
     private OrderItems $orderItems;
     private Config $config;
     private PriceFormatter $priceFormatter;
+    private NewCustomerResolverInterface $newCustomerResolver;
 
     public function __construct(
         OrderItems $orderItems,
         Config $config,
-        PriceFormatter $priceFormatter
+        PriceFormatter $priceFormatter,
+        NewCustomerResolverInterface $newCustomerResolver
     ) {
         $this->orderItems = $orderItems;
         $this->config = $config;
         $this->priceFormatter = $priceFormatter;
+        $this->newCustomerResolver = $newCustomerResolver;
     }
 
     /**
@@ -81,7 +85,7 @@ class Purchase implements EventInterface
             'email' => $order->getCustomerEmail() ?? '',
             'first_name' => $order->getCustomerFirstname() ?? '',
             'last_name' => $order->getCustomerLastname() ?? '',
-            'new_customer' => $order->getCustomerIsGuest() ? 'true' : 'false'
+            'new_customer' => $this->newCustomerResolver->isNewCustomer($order) ? 'true' : 'false'
         ];
     }
 

--- a/DataLayer/Event/PurchaseWebhookEvent.php
+++ b/DataLayer/Event/PurchaseWebhookEvent.php
@@ -6,6 +6,7 @@ namespace Tagging\GTM\DataLayer\Event;
 
 use Magento\Framework\HTTP\ClientFactory;
 use Magento\Framework\Serialize\Serializer\Json;
+use Tagging\GTM\Api\NewCustomerResolverInterface;
 use Tagging\GTM\DataLayer\Tag\Order\OrderItems;
 use Magento\Sales\Api\Data\OrderInterface;
 use Tagging\GTM\Util\PriceFormatter;
@@ -22,6 +23,7 @@ class PurchaseWebhookEvent
     private $priceFormatter;
     private LoggerInterface $logger;
     private Debugger $debugger;
+    private NewCustomerResolverInterface $newCustomerResolver;
 
     public function __construct(
         Json            $json,
@@ -30,7 +32,8 @@ class PurchaseWebhookEvent
         Config          $config,
         PriceFormatter  $priceFormatter,
         LoggerInterface $logger,
-        Debugger $debugger
+        Debugger $debugger,
+        NewCustomerResolverInterface $newCustomerResolver
     ) {
         $this->json = $json;
         $this->clientFactory = $clientFactory;
@@ -39,6 +42,7 @@ class PurchaseWebhookEvent
         $this->priceFormatter = $priceFormatter;
         $this->logger = $logger;
         $this->debugger = $debugger;
+        $this->newCustomerResolver = $newCustomerResolver;
     }
 
     public function purchase(OrderInterface $order)
@@ -122,7 +126,7 @@ class PurchaseWebhookEvent
                 "email" => $order->getCustomerEmail() ?? '',
                 "first_name" => $order->getCustomerFirstname() ?? '',
                 "last_name" => $order->getCustomerLastname() ?? '',
-                "new_customer" => (string)($order->getCustomerIsGuest() ? "true" : "false")
+                "new_customer" => (string)($this->newCustomerResolver->isNewCustomer($order) ? "true" : "false")
             ];
         } catch (\Exception $e) {
             $this->debugger->debug($e->getMessage());

--- a/DataLayer/Tag/Order/UserData.php
+++ b/DataLayer/Tag/Order/UserData.php
@@ -8,18 +8,22 @@ use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Tagging\GTM\Api\Data\TagInterface;
+use Tagging\GTM\Api\NewCustomerResolverInterface;
 
 class UserData implements TagInterface
 {
     private CheckoutSession $checkoutSession;
     private OrderRepositoryInterface $orderRepository;
+    private NewCustomerResolverInterface $newCustomerResolver;
 
     public function __construct(
         CheckoutSession $checkoutSession,
-        OrderRepositoryInterface $orderRepository
+        OrderRepositoryInterface $orderRepository,
+        NewCustomerResolverInterface $newCustomerResolver
     ) {
         $this->checkoutSession = $checkoutSession;
         $this->orderRepository = $orderRepository;
+        $this->newCustomerResolver = $newCustomerResolver;
     }
 
     /**
@@ -54,7 +58,7 @@ class UserData implements TagInterface
             'email' => $order->getCustomerEmail() ?? '',
             'first_name' => $order->getCustomerFirstname() ?? '',
             'last_name' => $order->getCustomerLastname() ?? '',
-            'new_customer' => $order->getCustomerIsGuest() ? 'true' : 'false'
+            'new_customer' => $this->newCustomerResolver->isNewCustomer($order) ? 'true' : 'false'
         ];
     }
 

--- a/Model/NewCustomerResolver/IsGuestResolver.php
+++ b/Model/NewCustomerResolver/IsGuestResolver.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Tagging\GTM\Model\NewCustomerResolver;
+
+use Magento\Sales\Api\Data\OrderInterface;
+use Tagging\GTM\Api\NewCustomerResolverInterface;
+
+/**
+ * Default resolver: treats guest orders as new customers.
+ *
+ * Preserves the historical behavior of the module. Override via a DI
+ * preference in your own module to implement a different heuristic.
+ */
+class IsGuestResolver implements NewCustomerResolverInterface
+{
+    public function isNewCustomer(OrderInterface $order): bool
+    {
+        return (bool)$order->getCustomerIsGuest();
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -2,6 +2,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="Tagging\GTM\Api\CheckoutSessionDataProviderInterface" type="Tagging\GTM\SessionDataProvider\CheckoutSessionDataProvider"/>
     <preference for="Tagging\GTM\Api\CustomerSessionDataProviderInterface" type="Tagging\GTM\SessionDataProvider\CustomerSessionDataProvider"/>
+    <preference for="Tagging\GTM\Api\NewCustomerResolverInterface" type="Tagging\GTM\Model\NewCustomerResolver\IsGuestResolver"/>
 
     <type name="Tagging\GTM\Logger\Debugger">
         <arguments>


### PR DESCRIPTION
## Summary

The `new_customer` field in the data layer is currently hardcoded to `$order->getCustomerIsGuest()` in **three** separate call sites:

- `DataLayer/Event/Purchase.php:84` — used by the MageWire/Hyva customer-data push via `Observer/TriggerPurchaseDataLayerEvent`
- `DataLayer/Tag/Order/UserData.php:57` — used by the shared Luma/Hyva success-page layout (`view/frontend/layout/checkout_onepage_success.xml`)
- `DataLayer/Event/PurchaseWebhookEvent.php:125` — used by the server-to-server webhook

Two problems with this:

1. **No upgrade-safe extension point.** A merchant plugging into one location silently misses the other two. There is no `ProcessorInterface` hook for the webhook path, and `afterGet` plugins on `Purchase` don't cover the success-page tag.
2. **`isGuest()` is a poor proxy for "new customer".** A returning customer can check out as a guest, and a new customer can register an account. More importantly, shops that convert guest orders into customer accounts on `sales_order_place_after` observe `isGuest() === false` by the time the value is read, so Google Ads' new-customer bid-modifier never receives a signal.

This PR extracts the check into `NewCustomerResolverInterface` (`isNewCustomer(OrderInterface): bool`) with a default `IsGuestResolver` implementation that preserves existing behavior. All three call sites now delegate to the resolver.

### For merchants

Override the default by adding a preference in your own module's `di.xml`:

```xml
<preference for="Tagging\GTM\Api\NewCustomerResolverInterface"
            type="Vendor\Module\Model\PriorOrderCountResolver"/>
```

### Backwards compatibility

No behavior change for existing installations — the default resolver returns `(bool)$order->getCustomerIsGuest()`, matching the previous three hardcoded expressions.

## Test plan

- [ ] `bin/magento setup:di:compile` succeeds (new interface + preference resolve)
- [ ] Existing `TriggerPurchaseDataLayerEventTest` integration test still passes
- [ ] Guest checkout on success page emits `new_customer: "true"` in dataLayer (default behavior preserved)
- [ ] Registered customer checkout emits `new_customer: "false"` (default behavior preserved)
- [ ] Webhook payload contains matching `new_customer` value
- [ ] A custom preference (e.g. always-true resolver) takes effect across all three emit points

https://claude.ai/code/session_01KrUuLFtrNMyY2ZuwrvH8db

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrUuLFtrNMyY2ZuwrvH8db)_