### PR TITLE
Prevent duplicate purchase events via localStorage deduplication

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "tagginggroup/gtm",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "OSL-3.0",
   "type": "magento2-module",
   "description": "AdPage tagging integration for Magento 2",

--- a/view/frontend/templates/hyva/script-pusher.phtml
+++ b/view/frontend/templates/hyva/script-pusher.phtml
@@ -33,6 +33,43 @@ declare(strict_types=1);
             return;
         }
 
+        // Prevent the same purchase from being pushed more than once per browser.
+        // The in-memory hash above only guards a single page load, while a purchase
+        // can be emitted by several sources (server-rendered layout event and the
+        // customerData "gtm-checkout" section) and re-rendered on every reload of
+        // the success page. Purchase events carry a stable ecommerce.transaction_id;
+        // other events do not, so this guard only applies to trytagging_purchase.
+        if (eventData.event === 'trytagging_purchase' && eventData.ecommerce && eventData.ecommerce.transaction_id) {
+            const transactionId = String(eventData.ecommerce.transaction_id);
+            const storageKey = 'Tagging_GTM_PURCHASED_TRANSACTIONS';
+            let purchasedTransactions = [];
+            try {
+                purchasedTransactions = JSON.parse(window.localStorage.getItem(storageKey) || '[]');
+                if (!Array.isArray(purchasedTransactions)) {
+                    purchasedTransactions = [];
+                }
+            } catch (error) {
+                purchasedTransactions = [];
+            }
+
+            if (purchasedTransactions.indexOf(transactionId) !== -1) {
+                googleTagManager2Logger('Warning: Purchase already tracked for transaction ' + transactionId, eventData);
+                return;
+            }
+
+            purchasedTransactions.push(transactionId);
+            // Keep the list bounded so localStorage does not grow indefinitely.
+            if (purchasedTransactions.length > 50) {
+                purchasedTransactions = purchasedTransactions.slice(-50);
+            }
+            try {
+                window.localStorage.setItem(storageKey, JSON.stringify(purchasedTransactions));
+            } catch (error) {
+                // localStorage unavailable (private mode / disabled) — fall back to the
+                // in-memory hash guard only.
+            }
+        }
+
         if (!message) {
             message = 'push (unknown) [unknown]';
         }

--- a/view/frontend/web/js/push.js
+++ b/view/frontend/web/js/push.js
@@ -37,6 +37,55 @@ define(["googleTagManagerLogger"], function (logger) {
       return;
     }
 
+    // Prevent the same purchase from being pushed more than once per browser.
+    // The in-memory hash above only guards a single page load, while a purchase
+    // can be emitted by several sources (server-rendered layout event and the
+    // customerData "gtm-checkout" section) and re-rendered on every reload of
+    // the success page. Purchase events carry a stable ecommerce.transaction_id;
+    // other events do not, so this guard only applies to trytagging_purchase.
+    if (
+      cleanEventData.event === "trytagging_purchase" &&
+      cleanEventData.ecommerce &&
+      cleanEventData.ecommerce.transaction_id
+    ) {
+      const transactionId = String(cleanEventData.ecommerce.transaction_id);
+      const storageKey = "Tagging_GTM_PURCHASED_TRANSACTIONS";
+      let purchasedTransactions = [];
+      try {
+        purchasedTransactions = JSON.parse(
+          window.localStorage.getItem(storageKey) || "[]"
+        );
+        if (!Array.isArray(purchasedTransactions)) {
+          purchasedTransactions = [];
+        }
+      } catch (error) {
+        purchasedTransactions = [];
+      }
+
+      if (purchasedTransactions.indexOf(transactionId) !== -1) {
+        logger(
+          "Warning: Purchase already tracked for transaction " + transactionId,
+          eventData
+        );
+        return;
+      }
+
+      purchasedTransactions.push(transactionId);
+      // Keep the list bounded so localStorage does not grow indefinitely.
+      if (purchasedTransactions.length > 50) {
+        purchasedTransactions = purchasedTransactions.slice(-50);
+      }
+      try {
+        window.localStorage.setItem(
+          storageKey,
+          JSON.stringify(purchasedTransactions)
+        );
+      } catch (error) {
+        // localStorage unavailable (private mode / disabled) — fall back to the
+        // in-memory hash guard only.
+      }
+    }
+
     if (!message) {
       message = "push (unknown) [unknown]";
     }


### PR DESCRIPTION
## Summary

This change adds persistent browser-level deduplication for purchase events to prevent the same transaction from being tracked multiple times. Purchase events can be emitted from multiple sources (server-rendered layout events and customerData sections) and re-rendered on every success page reload, causing duplicate GTM events. This fix uses localStorage to track transaction IDs across page loads.

## Key Changes

- **Added localStorage-based deduplication** in both `push.js` and `script-pusher.phtml`:
  - Maintains a list of tracked transaction IDs in `Tagging_GTM_PURCHASED_TRANSACTIONS` localStorage key
  - Only applies to `trytagging_purchase` events (which carry stable `ecommerce.transaction_id`)
  - Checks if a transaction has already been tracked before pushing the event
  - Gracefully handles localStorage unavailability (private mode, disabled) by falling back to in-memory guard

- **Bounded storage management**:
  - Keeps the transaction list limited to 50 most recent entries to prevent localStorage from growing indefinitely
  - Includes error handling for JSON parsing and storage operations

- **Version bump**: Updated `composer.json` from 1.6.0 to 1.6.1

## Implementation Details

The deduplication logic:
1. Extracts the `transaction_id` from purchase events
2. Retrieves the stored list of previously tracked transactions from localStorage
3. Returns early if the transaction was already tracked (logs warning)
4. Adds the new transaction ID to the list and persists it
5. Maintains a sliding window of the 50 most recent transactions to bound storage usage

The implementation is identical in both files to ensure consistency across different template contexts (standard and Hyva theme).

https://claude.ai/code/session_01DQvtz7r6vxm64uRZ4YEKoi