### PR TITLE
Add shipping, base currency, and payment data to purchase events

### DIFF
--- a/DataLayer/Event/PurchaseWebhookEvent.php
+++ b/DataLayer/Event/PurchaseWebhookEvent.php
@@ -102,6 +102,24 @@ class PurchaseWebhookEvent
             ]
         ];
 
+        // Additional shipping, base currency and payment data used by AdPage to
+        // calculate the actual profit (COGS, carrier rate, payment fees) per order.
+        // Purely additive: existing keys keep their name, meaning and value.
+        try {
+            $data['ecommerce'] += [
+                'shipping_method' => $order->getShippingDescription() ?? '',
+                'shipping_method_code' => $order->getShippingMethod() ?? '',
+                'shipping_excl_tax' => $this->priceFormatter->format((float)$order->getShippingAmount()),
+                'base_shipping_excl_tax' => $this->priceFormatter->format((float)$order->getBaseShippingAmount()),
+                'base_value' => $this->priceFormatter->format((float)$order->getBaseGrandTotal()),
+                'base_tax' => $this->priceFormatter->format((float)$order->getBaseTaxAmount()),
+                'base_currency' => $order->getBaseCurrencyCode() ?? '',
+                'payment_type' => $order->getPayment() ? (string)$order->getPayment()->getMethod() : ''
+            ];
+        } catch (\Exception $e) {
+            $this->debugger->debug('PurchaseWebhookEvent::purchase(): could not resolve shipping/base data: ' . $e->getMessage());
+        }
+
         try {
             $data['user_data'] = [
                 "customer_id" => $order->getCustomerId() ?? '',

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "tagginggroup/gtm",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "license": "OSL-3.0",
   "type": "magento2-module",
   "description": "AdPage tagging integration for Magento 2",


### PR DESCRIPTION
## Summary

Extends the purchase webhook event to include additional order data (shipping details, base currency values, and payment method) that AdPage uses to calculate actual profit metrics per order, including COGS, carrier rates, and payment fees.

## Changes

- **PurchaseWebhookEvent.php**: Added new ecommerce data fields to the purchase event payload:
  - Shipping information: `shipping_method`, `shipping_method_code`, `shipping_excl_tax`, `base_shipping_excl_tax`
  - Base currency values: `base_value`, `base_tax`, `base_currency`
  - Payment method: `payment_type`
  - All new fields are additive and preserve existing keys and values
  - Wrapped in try-catch with debug logging to handle potential data resolution failures gracefully

- **composer.json**: Version bump from 1.6.0 to 1.7.0

## Implementation Details

- Uses the existing `priceFormatter` service to format monetary values consistently
- Safely handles nullable order properties with null coalescing operators
- Includes comprehensive error handling with debug logging for troubleshooting
- Maintains backward compatibility by only adding new keys to the ecommerce data structure

https://claude.ai/code/session_01FtDTszbhPXRNU49GjSuiPD